### PR TITLE
Bug 817730: Reconnect to client if connection gets lost during startup

### DIFF
--- a/src/rilproxy.c
+++ b/src/rilproxy.c
@@ -183,7 +183,13 @@ int main(int argc, char **argv) {
       }
       LOGE("Could not connect to %s socket, retrying: %s\n",
            RILD_SOCKET_NAME, strerror(errno));
-      sleep(1);
+
+      connect_fds.fd = rilproxy_conn;
+      connect_fds.events = POLLIN;
+      connect_fds.revents = 0;
+      if (poll(&connect_fds, 1, 1000) > 0) {
+        goto reconnect_rilproxy;
+      }
     }
     LOGD("Connected to socket %s\n", RILD_SOCKET_NAME);
     char data[1024];
@@ -240,6 +246,7 @@ int main(int argc, char **argv) {
       }
     }
     close(rild_rw);
+  reconnect_rilproxy:
     close(rilproxy_rw);
   }
   return 0;


### PR DESCRIPTION
If the RIL client wants to reconnect to rilproxy, but rilproxy is blocked
by connecting to rild, the RIL client gets blocked as well. With this patch
rilproxy will detect attempts by the client to re-connect and accept them
immediatelly.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
